### PR TITLE
feat: Conditionally save deep link data

### DIFF
--- a/Tapp-Core/src/main/java/com/example/tapp/TappExtensions.kt
+++ b/Tapp-Core/src/main/java/com/example/tapp/TappExtensions.kt
@@ -237,8 +237,11 @@ internal fun TappEngine.handleReferralCallbackNative(
                             Logger.logInfo("Extracted linkToken Native: $linkToken")
                         }
 
-                        saveDeepLinkUrl(url.toString())
-                        saveLinkToken(linkToken)
+                        if(!tappUrlResponse.error){
+                            saveDeepLinkUrl(url.toString())
+                            saveLinkToken(linkToken)
+                        }
+
                         setProcessedReferralEngine()
 
                         dependencies.tappInstance?.deferredLinkDelegate?.didReceiveDeferredLink(response)


### PR DESCRIPTION
Only save the deep link URL and link token if the Tapp URL response does not contain an error.